### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '3.0' ]
+
+    runs-on: ubuntu-latest
+    name: OS Ruby ${{matrix.ruby}}
+    container: ruby:${{matrix.ruby}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Show Ruby Version
+      run: |
+        ruby -v
+
+    - name: Run tests
+      run: |
+        rake test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ on:
 #    - cron: '42 5 * * *'
 
 jobs:
-  test:
+  test-in-container:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
 
     runs-on: ubuntu-latest
     name: OS Ruby ${{matrix.ruby}}
@@ -28,4 +28,23 @@ jobs:
     - name: Run tests
       run: |
         rake test
+
+  test-natively:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        ruby-version: ['3.0']
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Ruby ${{matrix.ruby-version}}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Run tests
+      run: rake test
 


### PR DESCRIPTION
to run the tests on various versions of Ruby and on the 3 major OS-es on every push an pull-request.

Part of my [Daily CI](https://dev.to/szabgab/the-2022-december-ci-challenge-5dof) project.

And [here](https://dev.to/szabgab/a-javascript-bug-and-github-workflow-ci-for-the-four-pillars-ruby-gem-1gbg) is the article about this PR.